### PR TITLE
#8 Added issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+﻿blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/issue-template.yml
+++ b/.github/ISSUE_TEMPLATE/issue-template.yml
@@ -1,0 +1,14 @@
+﻿name: "Issue"
+description: "Create a new issue to break down a user story into smaller, manageable tasks."
+labels: [ "enhancement" ]
+projects: [ "kartAI/15" ]
+assignees:
+  - jathavaan
+
+body:
+  - type: textarea
+    attributes:
+      label: "Task description"
+      description: "Describe the issue in detail explaining how the issue should be completed."
+    validations:
+      required: true


### PR DESCRIPTION
This pull request introduces new configuration for GitHub issue templates, enabling blank issues and adding a structured template for creating new issues. These changes help standardize how issues are reported and managed in the repository.

**Issue template configuration:**

* Added `.github/ISSUE_TEMPLATE/issue-template.yml` to define a new issue template with a name, description, default label (`enhancement`), project assignment, default assignee, and a required task description field.

**Repository settings:**

* Enabled the creation of blank issues by adding `blank_issues_enabled: true` to `.github/ISSUE_TEMPLATE/config.yml`.